### PR TITLE
🐛 Fix[#73]: 고유 문자열을 통한 금융망 계정 생성 이메일 중복방지

### DIFF
--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/service/event/UserSignupListener.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/service/event/UserSignupListener.java
@@ -7,6 +7,7 @@ import com.saeparam.HeyRoutine.domain.user.dto.response.BankUserMakeResponseDto;
 import com.saeparam.HeyRoutine.global.infra.http.bank.WebClientBankUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -21,6 +22,9 @@ class UserSignupListener {
     private final UserAccountUpdater userAccountUpdater;
     private final FinanceService financeService;
 
+    @Value("${bank.unique}")
+    private String unique;
+
     /**
      * UserSignedUpEvent가 발행되면, 회원가입 트랜잭션이 '커밋된 후에' 이 메서드가 실행됩니다.
      * 이를 통해 Race Condition을 방지합니다.
@@ -30,7 +34,7 @@ class UserSignupListener {
 
     public void handleUserSignedUp(UserSignedUpEvent event) {
 
-        log.info("회원가입 트랜잭션 커밋 확인. 비동기 계좌 생성을 시작합니다. email: {}", event.getEmail());
+        log.info("회원가입 트랜잭션 커밋 확인. 비동기 계좌 생성을 시작합니다. email: {}", unique+event.getEmail());
         bankAccountMake(event.getEmail());
     }
 

--- a/src/main/java/com/saeparam/HeyRoutine/global/infra/http/bank/WebClientBankUtil.java
+++ b/src/main/java/com/saeparam/HeyRoutine/global/infra/http/bank/WebClientBankUtil.java
@@ -35,6 +35,9 @@ public class WebClientBankUtil {
     @Value("${bank.api-key}")
     private String apiKey;
 
+    @Value("${bank.unique}")
+    private String unique;
+
     private String institutionCode="00100";
     private String fintechAppNo="001";
 
@@ -187,7 +190,7 @@ public class WebClientBankUtil {
     public <T, V> Mono<T> makeUserAccount(String email, V requestDto, Class<T> responseDtoClass) {
         String url=baseUrl+apiVersion+"/member";
         BankUserMakeRequestDto bankUserMakeRequestDto = BankUserMakeRequestDto.builder()
-                .userId(email)
+                .userId(unique+email)
                 .apiKey(apiKey)
                 .build();
         return webClientConfig.webClient().method(HttpMethod.POST)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,7 @@ cloud:
       secret-key: ${cloud.aws.s3.secret-key}
 
 bank:
+  unique: ${bank.unique}
   base-url: ${bank.base-url}
   api-version: ${bank.api-version}
   api-key: ${bank.api-key}


### PR DESCRIPTION
## 📌 이슈 번호
> #73

## 💬 리뷰 포인트
> 금융망 계정 생성 시 email 중복 문제 해결을 위해 email에 고유 문자열을 추가하여 중복 방지 로직 적용

## 🚀 상세 설명
> 기존에는 HeyRoutine 내부에서만 email 중복을 체크했으나, 금융망 전체에서 email 중복이 발생할 수 있는 문제를 발견
> 금융망 계정 생성 API 호출 시 email의 고유성을 보장하기 위해 email에 유니크한 문자열을 추가하여 중복을 방지하도록 수정
> 이를 통해 금융망 계정 생성이 정상적으로 진행되고, 이후 입출금 계좌 및 거래 기록 생성이 원활하게 이루어짐..!

## 📸 스크린샷
<img width="1585" height="115" alt="image" src="https://github.com/user-attachments/assets/1fc6edb0-57da-4146-a57b-1d7a274da77c" />

## 📢 노트
고유값을 email에 추가하여 중복 문제를 해결했습니다.