### PR TITLE
[FEAT] 누락된 API 및 기능 구현

### DIFF
--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineServiceImpl.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineServiceImpl.java
@@ -530,13 +530,21 @@ public class GroupRoutineServiceImpl implements GroupRoutineService {
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
         RoutineRecord record = routineRecordRepository.findRecordByDateAndRoutine(user, routine, startOfDay, endOfDay)
-                .orElse(RoutineRecord.builder()
-                        .user(user)
-                        .routine(routine)
-                        .doneCheck(statusDto.getStatus())
-                        .build());
+                .orElseGet(() -> {
+                    RoutineRecord newRecord = RoutineRecord.builder()
+                            .user(user)
+                            .routine(routine)
+                            .doneCheck(statusDto.getStatus())
+                            .build();
+                    newRecord.setCreatedDate(startOfDay);
+                    newRecord.setModifiedDate(startOfDay);
+                    return newRecord;
+                });
 
         record.updateDoneCheck(statusDto.getStatus());
+        if (record.getId() != 0) {
+            record.setModifiedDate(LocalDateTime.now());
+        }
         routineRecordRepository.save(record);
     }
 

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/controller/UserController.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/controller/UserController.java
@@ -162,6 +162,22 @@ public class UserController {
         return ResponseEntity.ok().body(ApiResponse.onSuccess(result));
     }
 
+    /**
+     * 프로필 이미지 변경 API
+     * @param token Bearer 토큰
+     * @param requestDto 프로필 이미지 URL 요청 DTO
+     * @return 성공 메시지
+     */
+    @PutMapping("/profileImage")
+    @Operation(summary = "프로필 이미지 변경 API", description = "프로필 이미지를 변경합니다.")
+    public ResponseEntity<?> updateProfileImage(
+            @RequestHeader("Authorization") String token,
+            @RequestBody UpdateProfileImageDto requestDto) {
+        UUID userId = jwtTokenProvider.getUserId(token.substring(7));
+        userService.updateProfileImage(userId, requestDto.getProfileImageUrl());
+        return ResponseEntity.ok().body(ApiResponse.onSuccess(null, "프로필 이미지 변경 성공"));
+    }
+
     // 탈퇴
 
 

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/controller/UserController.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/controller/UserController.java
@@ -2,12 +2,9 @@ package com.saeparam.HeyRoutine.domain.user.controller;
 
 
 
-import com.saeparam.HeyRoutine.domain.user.dto.request.ResetPasswordDto;
+import com.saeparam.HeyRoutine.domain.user.dto.request.*;
 import com.saeparam.HeyRoutine.global.web.response.ApiResponse;
 import com.saeparam.HeyRoutine.domain.user.dto.JwtToken;
-import com.saeparam.HeyRoutine.domain.user.dto.request.ReissueDto;
-import com.saeparam.HeyRoutine.domain.user.dto.request.SignInDto;
-import com.saeparam.HeyRoutine.domain.user.dto.request.SignUpDto;
 import com.saeparam.HeyRoutine.domain.user.dto.response.UserDto;
 import com.saeparam.HeyRoutine.domain.user.service.UserService;
 import com.saeparam.HeyRoutine.global.security.jwt.JwtTokenProvider;
@@ -113,17 +110,17 @@ public class UserController {
     }
 
     /**
-     * mypage에서 비밀번호 재설정
-     * @param token
-     * @param password
-     * @return
+     * 마이페이지 비밀번호 재설정
+     * @param token 인증 토큰
+     * @param dto 기존 비밀번호와 새 비밀번호
      */
-    @PatchMapping("/mypage-password")
-    @Operation(summary = "비밀번호 재설정 API", description = "비밀번호를 재설정합니다.")
-    public ResponseEntity<?> mypageResetPassword(@RequestHeader("Authorization") String token,@RequestParam("password") String password) {
+    @PostMapping("/mypage-password")
+    @Operation(summary = "비밀번호 재설정 API", description = "마이페이지에서 비밀번호를 재설정합니다.")
+    public ResponseEntity<?> mypageResetPassword(@RequestHeader("Authorization") String token,
+                                                 @RequestBody MypageResetPasswordRequestDto dto) {
         UUID userId = jwtTokenProvider.getUserId(token.substring(7));
-        String result=userService.mypageResetPassword(userId,password);
-        return ResponseEntity.ok().body(ApiResponse.onSuccess(result));
+        userService.mypageResetPassword(userId, dto.getExsPassword(), dto.getNewPassword());
+        return ResponseEntity.ok().body(ApiResponse.onSuccess(null, "비밀번호 변경 완료."));
     }
 
     /**

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/controller/UserController.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/controller/UserController.java
@@ -2,12 +2,9 @@ package com.saeparam.HeyRoutine.domain.user.controller;
 
 
 
-import com.saeparam.HeyRoutine.domain.user.dto.request.ResetPasswordDto;
+import com.saeparam.HeyRoutine.domain.user.dto.request.*;
 import com.saeparam.HeyRoutine.global.web.response.ApiResponse;
 import com.saeparam.HeyRoutine.domain.user.dto.JwtToken;
-import com.saeparam.HeyRoutine.domain.user.dto.request.ReissueDto;
-import com.saeparam.HeyRoutine.domain.user.dto.request.SignInDto;
-import com.saeparam.HeyRoutine.domain.user.dto.request.SignUpDto;
 import com.saeparam.HeyRoutine.domain.user.dto.response.UserDto;
 import com.saeparam.HeyRoutine.domain.user.service.UserService;
 import com.saeparam.HeyRoutine.global.security.jwt.JwtTokenProvider;
@@ -134,6 +131,18 @@ public class UserController {
     public ResponseEntity<?> resetPassword(@RequestBody ResetPasswordDto resetPasswordDto) {
         String result=userService.resetPassword(resetPasswordDto);
         return ResponseEntity.ok().body(ApiResponse.onSuccess(result));
+    }
+
+    /**
+     * 마케팅 수신 여부 업데이트
+     */
+    @PatchMapping("/marketing")
+    @Operation(summary = "마케팅 수신 동의/거부 API", description = "마케팅 수신 여부를 업데이트합니다.")
+    public ResponseEntity<?> updateIsMarketing(@RequestHeader("Authorization") String token,
+                                               @RequestBody MarketingRequestDto marketingRequestDto) {
+        UUID userId = jwtTokenProvider.getUserId(token.substring(7));
+        userService.updateIsMarketing(userId, marketingRequestDto.isMarketing());
+        return ResponseEntity.ok().body(ApiResponse.onSuccess(null, "마케팅 수신 동의/거부 업데이트 성공"));
     }
 
 

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/MarketingRequestDto.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/MarketingRequestDto.java
@@ -1,0 +1,17 @@
+package com.saeparam.HeyRoutine.domain.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 마케팅 수신 동의 여부 업데이트 요청 DTO.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MarketingRequestDto {
+    private boolean isMarketing;
+}

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/MypageResetPasswordRequestDto.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/MypageResetPasswordRequestDto.java
@@ -1,0 +1,15 @@
+package com.saeparam.HeyRoutine.domain.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class MypageResetPasswordRequestDto {
+    private String exsPassword;
+    private String newPassword;
+}

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/SignUpDto.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/SignUpDto.java
@@ -21,6 +21,7 @@ public class SignUpDto {
     private String nickname; //닉네임
     private String profileImage;
     private List<Role> roles;
+    private Boolean isMarketing; // 마케팅 수신 동의 여부
 
     public User toEntity(SignUpDto signUpDto,String encodedPassword) {
 
@@ -31,6 +32,7 @@ public class SignUpDto {
                 .profileImage(signUpDto.getProfileImage())
                 .point(0L)
                 .roles(signUpDto.getRoles())
+                .isMarketing(signUpDto.getIsMarketing())
                 .build();
     }
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/UpdateProfileImageDto.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/UpdateProfileImageDto.java
@@ -1,0 +1,14 @@
+package com.saeparam.HeyRoutine.domain.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 프로필 이미지 변경 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class UpdateProfileImageDto {
+    /** 프로필 이미지 URL */
+    private String profileImageUrl;
+}

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/response/MyInfoResponseDto.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/response/MyInfoResponseDto.java
@@ -9,6 +9,9 @@ import lombok.*;
 @Builder
 public class MyInfoResponseDto {
     private String nickname;
-    private String userImage;
-
+    private String profileImage;
+    private String bankAccount;
+    private Long point;
+    private Boolean isMarketing;
+    private Boolean accountCertificationStatus;
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/entity/User.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/entity/User.java
@@ -88,6 +88,7 @@ public class User extends BaseTime implements UserDetails {
     this.password = password;
   }
 
+  public void setProfileImage(String profileImage) { this.profileImage = profileImage; }
   public static boolean hasRole(UserDetails user, Role role) {
     return user.getAuthorities().stream()
             .anyMatch(auth -> auth.getAuthority().equals(role.getRoleName()));

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/entity/User.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/entity/User.java
@@ -67,6 +67,8 @@ public class User extends BaseTime implements UserDetails {
 
   public void setAccountCertificationStatus(boolean accountCertificationStatus) { this.accountCertificationStatus = accountCertificationStatus; }
 
+  public void setMarketing(boolean isMarketing) { this.isMarketing = isMarketing; }
+
   @ElementCollection(fetch = FetchType.EAGER)
   @Builder.Default
   @Enumerated(EnumType.STRING) // Enum을 문자열로 저장

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/entity/User.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/entity/User.java
@@ -54,6 +54,9 @@ public class User extends BaseTime implements UserDetails {
   @Column
   private Long point;
 
+  @Column
+  private boolean isMarketing;
+
   public void setUserKey(String userKey) {
     this.userKey = userKey;
   }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
@@ -200,6 +200,20 @@ public class UserService {
         return "닉네임이 변경되었습니다";
     }
 
+    /**
+     * 마케팅 수신 여부 업데이트
+     *
+     * @param userId     사용자 ID
+     * @param isMarketing 마케팅 수신 여부
+     */
+    @Transactional
+    public void updateIsMarketing(UUID userId, boolean isMarketing) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        user.setMarketing(isMarketing);
+    }
+
+
     @Transactional
     public String logout(UUID userId) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
@@ -213,6 +213,18 @@ public class UserService {
         user.setMarketing(isMarketing);
     }
 
+    /**
+     * 프로필 이미지 변경
+     * @param userId 사용자 식별자
+     * @param profileImageUrl 변경할 프로필 이미지 URL
+     */
+    @Transactional
+    public void updateProfileImage(UUID userId, String profileImageUrl) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        user.setProfileImage(profileImageUrl);
+    }
+
 
     @Transactional
     public String logout(UUID userId) {

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
@@ -168,12 +168,25 @@ public class UserService {
     }
 
     @Transactional
-    public String mypageResetPassword(UUID userId, String password) {
+    public void mypageResetPassword(UUID userId, String exsPassword, String newPassword) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
-        String encodedPassword = passwordEncoder.encode(password);
-        user.setPassword(encodedPassword);
-        return "비밀번호가 변경되었습니다";
+        String encodedExistingPassword = user.getPassword();
+        String encodedExsPassword = passwordEncoder.encode(exsPassword);
+        String encodedNewPassword = passwordEncoder.encode(newPassword);
+
+        // 기존 비밀번호 검증
+        if (!passwordEncoder.matches(exsPassword, encodedExistingPassword)) {
+            throw new UserHandler(ErrorStatus.PASSWORD_NOT_MATCH);
+        }
+
+        // 새 비밀번호가 기존과 동일한지 확인
+        if (passwordEncoder.matches(newPassword, encodedExistingPassword) ||
+                passwordEncoder.matches(newPassword, encodedExsPassword)) {
+            throw new UserHandler(ErrorStatus.PASSWORD_SAME_AS_OLD);
+        }
+
+        user.setPassword(encodedNewPassword);
     }
 
     /**

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
@@ -128,8 +128,12 @@ public class UserService {
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         return MyInfoResponseDto.builder()
-                .userImage(user.getProfileImage())
+                .profileImage(user.getProfileImage())
                 .nickname(user.getNickname())
+                .bankAccount(user.getBankAccount())
+                .point(user.getPoint())
+                .isMarketing(user.isMarketing())
+                .accountCertificationStatus(user.isAccountCertificationStatus())
                 .build();
     }
 

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/service/event/UserSignupListener.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/service/event/UserSignupListener.java
@@ -7,6 +7,7 @@ import com.saeparam.HeyRoutine.domain.user.dto.response.BankUserMakeResponseDto;
 import com.saeparam.HeyRoutine.global.infra.http.bank.WebClientBankUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -21,6 +22,9 @@ class UserSignupListener {
     private final UserAccountUpdater userAccountUpdater;
     private final FinanceService financeService;
 
+    @Value("${bank.unique}")
+    private String unique;
+
     /**
      * UserSignedUpEvent가 발행되면, 회원가입 트랜잭션이 '커밋된 후에' 이 메서드가 실행됩니다.
      * 이를 통해 Race Condition을 방지합니다.
@@ -30,7 +34,7 @@ class UserSignupListener {
 
     public void handleUserSignedUp(UserSignedUpEvent event) {
 
-        log.info("회원가입 트랜잭션 커밋 확인. 비동기 계좌 생성을 시작합니다. email: {}", event.getEmail());
+        log.info("회원가입 트랜잭션 커밋 확인. 비동기 계좌 생성을 시작합니다. email: {}", unique+event.getEmail());
         bankAccountMake(event.getEmail());
     }
 

--- a/src/main/java/com/saeparam/HeyRoutine/global/infra/http/bank/WebClientBankUtil.java
+++ b/src/main/java/com/saeparam/HeyRoutine/global/infra/http/bank/WebClientBankUtil.java
@@ -35,6 +35,9 @@ public class WebClientBankUtil {
     @Value("${bank.api-key}")
     private String apiKey;
 
+    @Value("${bank.unique}")
+    private String unique;
+
     private String institutionCode="00100";
     private String fintechAppNo="001";
 
@@ -187,7 +190,7 @@ public class WebClientBankUtil {
     public <T, V> Mono<T> makeUserAccount(String email, V requestDto, Class<T> responseDtoClass) {
         String url=baseUrl+apiVersion+"/member";
         BankUserMakeRequestDto bankUserMakeRequestDto = BankUserMakeRequestDto.builder()
-                .userId(email)
+                .userId(unique+email)
                 .apiKey(apiKey)
                 .build();
         return webClientConfig.webClient().method(HttpMethod.POST)

--- a/src/main/java/com/saeparam/HeyRoutine/global/web/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/saeparam/HeyRoutine/global/web/response/code/status/ErrorStatus.java
@@ -39,6 +39,10 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "USER4003", "로그인 정보가 일치하지 않습니다."),
     USER_NOT_MATCH(HttpStatus.UNAUTHORIZED, "USER4005", "접근 권한이 없습니다."),
 
+    // password 응답
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "PASSWORD4000", "비밀번호가 맞지 않습니다."),
+    PASSWORD_SAME_AS_OLD(HttpStatus.CONFLICT, "PASSWORD4090", "기존 비밀번호와 동일합니다"),
+
     // mail 응답
     MAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MAIL5000", "이메일 전송에 에러가 발생했습니다."),
     MAIL_NUMBER_IS_NULL(HttpStatus.BAD_REQUEST,"MAIL4000","인증번호를 입력해주세요"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,7 @@ cloud:
       secret-key: ${cloud.aws.s3.secret-key}
 
 bank:
+  unique: ${bank.unique}
   base-url: ${bank.base-url}
   api-version: ${bank.api-version}
   api-key: ${bank.api-key}


### PR DESCRIPTION
## 📌 이슈 번호
> #75

## 💬 리뷰 포인트
> UserService 비밀번호/닉네임/프로필 이미지 변경 등 사용자 관련 주요 기능 구현 및 개선, 단체루틴 오류 수정  

## 🚀 상세 설명
- User Entity 마케팅 수신 여부 누락, 회원가입 시 isMarketing 추가
- myInfo 유저 닉네임, 프로필 뿐만 아니라 다양한 유저 관련 정보 제공(계좌번호, 인증 상태 등)
- 마케팅 수신동의 API 구현
- 프로필 사진 수정 API 구현
- 단체루틴 상세 등록/수정 시 발생하는 타임스탬프 수정
- 비밀번호 API 수정 필요 (검증이 빠짐)

## 📸 스크린샷
> (해당 PR과 관련된 화면이 있다면 첨부해주세요)

## 📢 노트
