### PR TITLE
[FEAT] [BUG] 개인/단체루틴 완료 요일 추가 및 마케팅, 상세조회 버그 수정, 회원탈퇴 구현

### DIFF
--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/controller/HomeController.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/controller/HomeController.java
@@ -41,11 +41,11 @@ public class HomeController {
      */
     @GetMapping("/groups")
     @Operation(summary = "내 단체루틴 조회 API", description = "사용자가 가입한 단체루틴 목록을 최신순으로 조회합니다.")
-    public ResponseEntity<ApiResponse<PaginatedResponse<GroupRoutineResponseDto.GroupRoutineInfo>>> getMyGroupRoutines(
+    public ResponseEntity<ApiResponse<PaginatedResponse<GroupRoutineResponseDto.MyGroupRoutineInfo>>> getMyGroupRoutines(
             @RequestHeader("Authorization") String token,
             @PageableDefault(page = 0, size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
         UUID uuid = jwtTokenProvider.getUserId(token.substring(7));
-        PaginatedResponse<GroupRoutineResponseDto.GroupRoutineInfo> response =
+        PaginatedResponse<GroupRoutineResponseDto.MyGroupRoutineInfo> response =
                 groupRoutineService.getMyGroupRoutines(uuid, pageable);
         if (response.items().isEmpty()) {
             return ResponseEntity.ok(ApiResponse.noContent());

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/dto/response/GroupRoutineResponseDto.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/dto/response/GroupRoutineResponseDto.java
@@ -94,6 +94,52 @@ public class GroupRoutineResponseDto {
     }
 
     /**
+     * <h4>내 단체 루틴 기본 정보</h4>
+     * <p>홈 화면에서 내가 가입한 단체 루틴을 조회할 때 사용되는 DTO 입니다.</p>
+     */
+    @Getter
+    @Builder
+    @Schema(description = "내 단체 루틴 기본 정보 DTO")
+    public static class MyGroupRoutineInfo {
+        @Schema(description = "단체 루틴 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "루틴 타입 (DAILY: 일상, FINANCE: 소비)", example = "FINANCE")
+        private RoutineType routineType;
+
+        @Schema(description = "단체 루틴 타이틀", example = "티끌모아 태산")
+        private String title;
+
+        @Schema(description = "단체 루틴 설명", example = "주 1회 가게부 작성, 뉴스 스크랩 관련 루틴")
+        private String description;
+
+        @Schema(description = "루틴 시작 시간 (HH:mm)", example = "20:00")
+        private String startTime;
+
+        @Schema(description = "루틴 종료 시간 (HH:mm)", example = "21:00")
+        private String endTime;
+
+        @Schema(description = "루틴 개수", example = "5")
+        private int routineNums;
+
+        @Schema(description = "참여중인 인원 수", example = "52")
+        private int peopleNums;
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "현재 루틴 진행률(소수점 첫째 자리)", example = "75.5")
+        private Double percent;
+
+        @Schema(description = "루틴 수행 요일 리스트", example = "[\"수\", \"일\"]")
+        private List<String> dayOfWeek;
+
+        @Schema(description = "이번 주 성공한 요일 리스트", example = "[\"수\"]")
+        private List<String> successDay;
+
+        @Schema(description = "현재 사용자의 참여 여부", example = "false")
+        private boolean isJoined;
+    }
+
+    /**
      * <h4>(공용) 상세 루틴 정보</h4>
      * <p>단체 루틴 상세 조회 시 사용되는 개별 루틴 정보 DTO 입니다.</p>
      */

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/dto/response/GroupRoutineResponseDto.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/dto/response/GroupRoutineResponseDto.java
@@ -151,8 +151,8 @@ public class GroupRoutineResponseDto {
         @Schema(description = "상세 루틴 ID", example = "1")
         private Long id;
 
-        @Schema(description = "이모지 ID", example = "1")
-        private Long emojiId;
+        @Schema(description = "이모지 URL", example = "https://example.com/emoji.png")
+        private String emojiUrl;
 
         @Schema(description = "루틴 이름", example = "커피 내리기")
         private String name;

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/dto/response/MyRoutineListShowResponseDto.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/dto/response/MyRoutineListShowResponseDto.java
@@ -6,11 +6,12 @@ import com.saeparam.HeyRoutine.domain.routine.enums.RoutineType;
 import lombok.*;
 
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * 개인 루틴 목록보기 Response
+ * 개인 루틴 목록 전체 조회 Response
  */
 @Getter
 @ToString
@@ -18,24 +19,23 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @Builder
 @Setter
-public class MyRoutineListResponseDto {
+public class MyRoutineListShowResponseDto {
     private Long id;
     private String title;
     private LocalTime startTime;
     private LocalTime endTime;
     private RoutineType routineType;
     private Set<DayType> dayTypes;
-
-    /**
-     * 현재 루틴 진행률(%)
-     */
+    /** 현재 루틴 진행률(%) */
     private double percent;
+    /** 이번 주 성공한 요일 리스트 */
+    private List<String> successDay;
 
-    public static MyRoutineListResponseDto toDto(MyRoutineList myRoutineList){
+    public static MyRoutineListShowResponseDto toDto(MyRoutineList myRoutineList){
         Set<DayType> days = myRoutineList.getRoutineDays().stream()
                 .map(routineDay -> routineDay.getDayType())
-                .collect(Collectors.toSet()); // toList() -> toSet()으로 변경
-        return MyRoutineListResponseDto.builder()
+                .collect(Collectors.toSet());
+        return MyRoutineListShowResponseDto.builder()
                 .id(myRoutineList.getId())
                 .title(myRoutineList.getTitle())
                 .startTime(myRoutineList.getStartTime())

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/GroupRoutineListDoneCheckRepository.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/GroupRoutineListDoneCheckRepository.java
@@ -56,4 +56,11 @@ public interface GroupRoutineListDoneCheckRepository extends JpaRepository<Group
      * @param user             기록을 삭제할 사용자
      */
     void deleteByGroupRoutineListAndUser(GroupRoutineList groupRoutineList, User user);
+
+    /**
+     * 특정 사용자의 모든 단체 루틴 완료 기록을 삭제합니다.
+     *
+     * @param user 삭제할 사용자
+     */
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/GroupRoutineListRepository.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/GroupRoutineListRepository.java
@@ -36,4 +36,12 @@ public interface GroupRoutineListRepository extends JpaRepository<GroupRoutineLi
                     "JOIN grl.userInRooms uir " +
                     "WHERE uir.user = :user")
     Page<GroupRoutineList> findAllByUser(@Param("user") User user, Pageable pageable);
+
+    /**
+     * 특정 사용자가 방장으로 있는 모든 단체 루틴을 조회합니다.
+     *
+     * @param user 방장 사용자
+     * @return 단체 루틴 목록
+     */
+    List<GroupRoutineList> findAllByUser(User user);
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/GuestbookRepository.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/GuestbookRepository.java
@@ -1,6 +1,7 @@
 package com.saeparam.HeyRoutine.domain.routine.repository;
 
 import com.saeparam.HeyRoutine.domain.routine.entity.Guestbook;
+import com.saeparam.HeyRoutine.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -17,4 +18,11 @@ public interface GuestbookRepository extends JpaRepository<Guestbook, Long> {
     Optional<Guestbook> findByIdAndGroupRoutineList(Long id, GroupRoutineList groupRoutineList);
 
     void deleteAllByGroupRoutineList(GroupRoutineList groupRoutineList);
+
+    /**
+     * 특정 사용자가 작성한 모든 방명록을 삭제합니다.
+     *
+     * @param user 삭제 대상 사용자
+     */
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/MyRoutineListRecordRepository.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/MyRoutineListRecordRepository.java
@@ -21,4 +21,11 @@ public interface MyRoutineListRecordRepository extends JpaRepository<MyRoutineLi
     List<MyRoutineListRecord> findByUserAndCreatedDateBetween(User user, LocalDateTime start, LocalDateTime end);
 
     void deleteByMyRoutineList(MyRoutineList myRoutineList);
+
+    /**
+     * 특정 사용자의 모든 개인 루틴 수행 기록을 삭제합니다.
+     *
+     * @param user 삭제 대상 사용자
+     */
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/MyRoutineListRepository.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/MyRoutineListRepository.java
@@ -33,4 +33,12 @@ public interface MyRoutineListRepository extends JpaRepository<MyRoutineList, Lo
     List<MyRoutineList> findAllByUserAndDay(@Param("user") User user, @Param("day") DayType day);
 
     Optional<MyRoutineList> findFirstByUserOrderByIdDesc(User user);
+
+    /**
+     * 특정 사용자가 소유한 모든 개인 루틴을 조회합니다.
+     *
+     * @param user 조회할 사용자
+     * @return 개인 루틴 목록
+     */
+    List<MyRoutineList> findAllByUser(User user);
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/RoutineRecordRepository.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/RoutineRecordRepository.java
@@ -45,5 +45,12 @@ public interface RoutineRecordRepository extends JpaRepository<RoutineRecord, Lo
             "AND rr.createdDate >= :startOfDay AND rr.createdDate <= :endOfDay " +
             "AND rr.routine IN :routines AND rr.doneCheck = true")
     long countCompletedRoutinesInList(User user, LocalDateTime startOfDay, LocalDateTime endOfDay, List<Routine> routines);
+
+    /**
+     * 특정 사용자의 모든 루틴 수행 기록을 삭제합니다.
+     *
+     * @param user 삭제 대상 사용자
+     */
+    void deleteAllByUser(User user);
 }
 

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/UserInRoomRepository.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/repository/UserInRoomRepository.java
@@ -53,4 +53,19 @@ public interface UserInRoomRepository extends JpaRepository<UserInRoom, Long> {
      */
     @Query("SELECT uir FROM UserInRoom uir JOIN FETCH uir.user WHERE uir.groupRoutineList = :groupRoutineList")
     List<UserInRoom> findByGroupRoutineList(@Param("groupRoutineList") GroupRoutineList groupRoutineList);
+
+    /**
+     * 특정 사용자가 참여중인 모든 단체 루틴 정보를 조회합니다.
+     *
+     * @param user 사용자
+     * @return 참여 정보 목록
+     */
+    List<UserInRoom> findAllByUser(User user);
+
+    /**
+     * 특정 사용자의 모든 단체 루틴 참여 정보를 삭제합니다.
+     *
+     * @param user 삭제할 사용자
+     */
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineService.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineService.java
@@ -31,9 +31,9 @@ public interface GroupRoutineService {
      *
      * @param id       현재 로그인한 사용자의 uuid
      * @param pageable 페이지 번호, 페이지 크기 정보를 담은 객체
-     * @return {@link GroupRoutineResponseDto.GroupRoutineInfo} 단체 루틴 목록 정보
+     * @return {@link GroupRoutineResponseDto.MyGroupRoutineInfo} 단체 루틴 목록 정보
      */
-    PaginatedResponse<GroupRoutineResponseDto.GroupRoutineInfo> getMyGroupRoutines(UUID id, Pageable pageable);
+    PaginatedResponse<GroupRoutineResponseDto.MyGroupRoutineInfo> getMyGroupRoutines(UUID id, Pageable pageable);
 
     /**
      * 키워드를 기준으로 단체 루틴을 검색합니다.

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineServiceImpl.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineServiceImpl.java
@@ -372,7 +372,7 @@ public class GroupRoutineServiceImpl implements GroupRoutineService {
         List<GroupRoutineResponseDto.RoutineInfo> routineInfos = routines.stream()
                 .map(r -> GroupRoutineResponseDto.RoutineInfo.builder()
                         .id(r.getId())
-                        .emojiId(r.getEmoji().getId())
+                        .emojiUrl(r.getEmoji().getEmojiUrl())
                         .name(r.getName())
                         .time(r.getTime())
                         .isCompleted(isJoined ? completedIds.contains(r.getId()) : null)

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineServiceImpl.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineServiceImpl.java
@@ -235,6 +235,8 @@ public class GroupRoutineServiceImpl implements GroupRoutineService {
                 .map(GroupRoutineMiddle::getRoutine)
                 .collect(Collectors.toList());
 
+
+        LocalDate today = LocalDate.now();
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineServiceImpl.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/GroupRoutineServiceImpl.java
@@ -54,17 +54,23 @@ public class GroupRoutineServiceImpl implements GroupRoutineService {
 
     @Override
     @Transactional(readOnly = true)
-    public PaginatedResponse<GroupRoutineResponseDto.GroupRoutineInfo> getMyGroupRoutines(UUID userId, Pageable pageable) {
+    public PaginatedResponse<GroupRoutineResponseDto.MyGroupRoutineInfo> getMyGroupRoutines(UUID userId, Pageable pageable) {
         // 1. 사용자 존재 여부 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 2. 가입한 단체 루틴 목록 조회 (최신순)
+        // 2. 이번 주 완료 기록 조회
+        LocalDate today = LocalDate.now();
+        LocalDate startOfWeek = today.with(java.time.DayOfWeek.MONDAY);
+        List<GroupRoutineListDoneCheck> weekRecords = groupRoutineListDoneCheckRepository
+                .findByUserAndCreatedDateBetween(user, startOfWeek.atStartOfDay(), LocalDateTime.now());
+
+        // 3. 가입한 단체 루틴 목록 조회 (최신순)
         Page<GroupRoutineList> routinePage = groupRoutineListRepository.findAllByUser(user, pageable);
 
 
-        // 3. 각 루틴에 대한 정보 매핑 및 페이지네이션 응답 생성
-        return PaginatedResponse.of(routinePage, routine -> toGroupRoutineInfo(routine, user, true));
+        // 4. 각 루틴에 대한 정보 매핑 및 페이지네이션 응답 생성
+        return PaginatedResponse.of(routinePage, routine -> toMyGroupRoutineInfo(routine, user, true, weekRecords));
     }
 
     @Override
@@ -229,7 +235,6 @@ public class GroupRoutineServiceImpl implements GroupRoutineService {
                 .map(GroupRoutineMiddle::getRoutine)
                 .collect(Collectors.toList());
 
-        LocalDate today = LocalDate.now();
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
@@ -679,6 +684,62 @@ public class GroupRoutineServiceImpl implements GroupRoutineService {
                 .peopleNums((int) peopleNums)
                 .percent(percent)
                 .dayOfWeek(dayOfWeek)
+                .isJoined(isJoined)
+                .build();
+    }
+
+    private GroupRoutineResponseDto.MyGroupRoutineInfo toMyGroupRoutineInfo(GroupRoutineList routine, User user, boolean includePercent,
+                                                                            List<GroupRoutineListDoneCheck> weekRecords) {
+        List<GroupRoutineMiddle> middles = groupRoutineMiddleRepository.findByRoutineList(routine);
+        int routineNums = middles.size();
+        long peopleNums = userInRoomRepository.countByGroupRoutineList(routine);
+
+        Double percent = null;
+        if (includePercent) {
+            List<Routine> routines = middles.stream()
+                    .map(GroupRoutineMiddle::getRoutine)
+                    .collect(Collectors.toList());
+
+            LocalDate today = LocalDate.now();
+            LocalDateTime startOfDay = today.atStartOfDay();
+            LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+            long doneCount = 0;
+            if (!routines.isEmpty()) {
+                List<RoutineRecord> records = routineRecordRepository.findRecordsByDateAndRoutines(user, startOfDay, endOfDay, routines);
+                doneCount = records.stream()
+                        .filter(RoutineRecord::isDoneCheck)
+                        .count();
+            }
+            percent = routineNums > 0 ? Math.round((double) doneCount * 1000 / routineNums) / 10.0 : 0.0;
+        }
+
+        boolean isJoined = routine.getUser().equals(user)
+                || userInRoomRepository.existsByGroupRoutineListAndUser(routine, user);
+
+        List<String> dayOfWeek = groupRoutinDaysRepository.findByGroupRoutineList(routine)
+                .stream()
+                .map(day -> day.getDayType().name())
+                .collect(Collectors.toList());
+
+        List<String> successDay = weekRecords == null ? Collections.emptyList() : weekRecords.stream()
+                .filter(record -> record.isDoneCheck() && record.getGroupRoutineList().equals(routine))
+                .map(record -> DayType.from(record.getCreatedDate().getDayOfWeek()).name())
+                .filter(dayOfWeek::contains)
+                .distinct()
+                .collect(Collectors.toList());
+
+        return GroupRoutineResponseDto.MyGroupRoutineInfo.builder()
+                .id(routine.getId())
+                .routineType(routine.getRoutineType())
+                .title(routine.getTitle())
+                .description(routine.getDescription())
+                .startTime(routine.getStartTime().format(TIME_FORMATTER))
+                .endTime(routine.getEndTime().format(TIME_FORMATTER))
+                .routineNums(routineNums)
+                .peopleNums((int) peopleNums)
+                .percent(percent)
+                .dayOfWeek(dayOfWeek)
+                .successDay(successDay)
                 .isJoined(isJoined)
                 .build();
     }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/MyRoutineListService.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/routine/service/MyRoutineListService.java
@@ -6,6 +6,7 @@ import com.saeparam.HeyRoutine.domain.routine.dto.request.RoutineInMyRoutineUpda
 import com.saeparam.HeyRoutine.domain.routine.dto.request.RoutineRequestDto;
 import com.saeparam.HeyRoutine.domain.routine.dto.request.RoutineUpdateRequestDto;
 import com.saeparam.HeyRoutine.domain.routine.dto.response.MyRoutineListResponseDto;
+import com.saeparam.HeyRoutine.domain.routine.dto.response.MyRoutineListShowResponseDto;
 import com.saeparam.HeyRoutine.domain.routine.dto.response.RoutineResponseDto;
 import com.saeparam.HeyRoutine.domain.routine.entity.*;
 import com.saeparam.HeyRoutine.domain.routine.enums.DayType;
@@ -72,13 +73,18 @@ public class MyRoutineListService {
     }
 
     @Transactional(readOnly = true)
-    public PaginatedResponse<MyRoutineListResponseDto> showMyRoutineList(UUID userId, DayType day, LocalDate date,Pageable pageable) {
+    public PaginatedResponse<MyRoutineListShowResponseDto> showMyRoutineList(UUID userId, DayType day, LocalDate date, Pageable pageable) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
         Page<MyRoutineList> myRoutineList = myRoutineListRepository.findByUserAndStartDateAfterAndDay(user, day, date, pageable);
 
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+
+        LocalDate today = LocalDate.now();
+        LocalDate startOfWeek = today.with(java.time.DayOfWeek.MONDAY);
+        List<MyRoutineListRecord> weekRecords = myRoutineListRecordRepository
+                .findByUserAndCreatedDateBetween(user, startOfWeek.atStartOfDay(), LocalDateTime.now());
 
         return PaginatedResponse.of(myRoutineList, list -> {
             // 상세 루틴 목록 조회
@@ -97,8 +103,15 @@ public class MyRoutineListService {
             }
             double percent = routineCount > 0 ? Math.round((double) doneCount * 1000 / routineCount) / 10.0 : 0.0;
 
-            MyRoutineListResponseDto dto = MyRoutineListResponseDto.toDto(list);
+            MyRoutineListShowResponseDto dto = MyRoutineListShowResponseDto.toDto(list);
             dto.setPercent(percent);
+
+            List<String> successDay = weekRecords.stream()
+                    .filter(record -> record.isDoneCheck() && record.getMyRoutineList().equals(list))
+                    .map(record -> DayType.from(record.getCreatedDate().getDayOfWeek()).name())
+                    .distinct()
+                    .collect(Collectors.toList());
+            dto.setSuccessDay(successDay);
             return dto;
         });
     }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/controller/UserController.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/controller/UserController.java
@@ -178,8 +178,14 @@ public class UserController {
         return ResponseEntity.ok().body(ApiResponse.onSuccess(null, "프로필 이미지 변경 성공"));
     }
 
-    // 탈퇴
-
-
-
+    /**
+     * 회원 탈퇴
+     */
+    @DeleteMapping("/delete")
+    @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴를 진행합니다.")
+    public ResponseEntity<?> deleteUser(@RequestHeader("Authorization") String token) {
+        UUID userId = jwtTokenProvider.getUserId(token.substring(7));
+        userService.deleteUser(userId);
+        return ResponseEntity.ok().body(ApiResponse.onSuccess(null, "회원탈퇴 성공"));
+    }
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/MarketingRequestDto.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/dto/request/MarketingRequestDto.java
@@ -1,5 +1,6 @@
 package com.saeparam.HeyRoutine.domain.user.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,5 +14,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class MarketingRequestDto {
+    @JsonProperty("status")
     private boolean isMarketing;
 }

--- a/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
+++ b/src/main/java/com/saeparam/HeyRoutine/domain/user/service/UserService.java
@@ -2,6 +2,20 @@ package com.saeparam.HeyRoutine.domain.user.service;
 
 
 import com.saeparam.HeyRoutine.domain.fcm.repository.FcmTokenRepository;
+import com.saeparam.HeyRoutine.domain.routine.entity.GroupRoutineList;
+import com.saeparam.HeyRoutine.domain.routine.entity.GroupRoutineMiddle;
+import com.saeparam.HeyRoutine.domain.routine.entity.UserInRoom;
+import com.saeparam.HeyRoutine.domain.routine.entity.MyRoutineList;
+import com.saeparam.HeyRoutine.domain.routine.repository.GroupRoutineListDoneCheckRepository;
+import com.saeparam.HeyRoutine.domain.routine.repository.GroupRoutineListRepository;
+import com.saeparam.HeyRoutine.domain.routine.repository.GroupRoutineMiddleRepository;
+import com.saeparam.HeyRoutine.domain.routine.repository.GroupRoutinDaysRepository;
+import com.saeparam.HeyRoutine.domain.routine.repository.GuestbookRepository;
+import com.saeparam.HeyRoutine.domain.routine.repository.MyRoutineListRecordRepository;
+import com.saeparam.HeyRoutine.domain.routine.repository.MyRoutineListRepository;
+import com.saeparam.HeyRoutine.domain.routine.repository.RoutineRecordRepository;
+import com.saeparam.HeyRoutine.domain.routine.repository.RoutineRepository;
+import com.saeparam.HeyRoutine.domain.routine.repository.UserInRoomRepository;
 import com.saeparam.HeyRoutine.domain.user.dto.response.MyInfoResponseDto;
 import com.saeparam.HeyRoutine.domain.user.service.event.UserSignedUpEvent;
 import com.saeparam.HeyRoutine.global.error.handler.TokenHandler;
@@ -28,6 +42,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -43,6 +58,16 @@ public class UserService {
     private final WebClientBankUtil webClientBankUtil;
     private final ApplicationEventPublisher eventPublisher;
     private final FcmTokenRepository fcmTokenRepository;
+    private final MyRoutineListRepository myRoutineListRepository;
+    private final MyRoutineListRecordRepository myRoutineListRecordRepository;
+    private final RoutineRepository routineRepository;
+    private final RoutineRecordRepository routineRecordRepository;
+    private final GroupRoutineListRepository groupRoutineListRepository;
+    private final GroupRoutinDaysRepository groupRoutinDaysRepository;
+    private final GroupRoutineListDoneCheckRepository groupRoutineListDoneCheckRepository;
+    private final GroupRoutineMiddleRepository groupRoutineMiddleRepository;
+    private final UserInRoomRepository userInRoomRepository;
+    private final GuestbookRepository guestbookRepository;
 
 
     @Transactional
@@ -250,5 +275,67 @@ public class UserService {
         fcmTokenRepository.deleteAllByUser(user);
 
         return "로그아웃 되었습니다.";
+    }
+
+    /**
+     * 회원 탈퇴 처리
+     *
+     * <p>사용자가 탈퇴할 때 개인 루틴, 단체 루틴 참여 정보, 관련 기록 및 FCM 토큰 등을
+     * 모두 삭제한 뒤 최종적으로 사용자 정보를 제거합니다.</p>
+     *
+     * @param userId 탈퇴할 사용자 ID
+     */
+    @Transactional
+    public void deleteUser(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // Refresh Token 제거
+        if (redisTemplate.opsForValue().get("RT:" + user.getId()) != null) {
+            redisTemplate.delete("RT:" + user.getId());
+        }
+
+        // FCM 토큰 제거
+        fcmTokenRepository.deleteAllByUser(user);
+
+        // 개인 루틴 및 기록 삭제
+        myRoutineListRecordRepository.deleteAllByUser(user);
+        List<MyRoutineList> myRoutineLists = myRoutineListRepository.findAllByUser(user);
+        myRoutineListRepository.deleteAll(myRoutineLists);
+
+        // 사용자가 방장인 단체 루틴 삭제
+        List<GroupRoutineList> ownedGroups = groupRoutineListRepository.findAllByUser(user);
+        for (GroupRoutineList group : ownedGroups) {
+            guestbookRepository.deleteAllByGroupRoutineList(group);
+            groupRoutineListDoneCheckRepository.deleteAllByGroupRoutineList(group);
+            userInRoomRepository.deleteAllByGroupRoutineList(group);
+
+            List<GroupRoutineMiddle> middles = groupRoutineMiddleRepository.findByRoutineList(group);
+            for (GroupRoutineMiddle middle : middles) {
+                routineRecordRepository.deleteAllByRoutine(middle.getRoutine());
+                routineRepository.delete(middle.getRoutine());
+            }
+            groupRoutineMiddleRepository.deleteAllByRoutineList(group);
+            groupRoutinDaysRepository.deleteAllByGroupRoutineList(group);
+            groupRoutineListRepository.delete(group);
+        }
+
+        // 사용자가 참여중인 단체 루틴에서 제거
+        List<UserInRoom> joinedRooms = userInRoomRepository.findAllByUser(user);
+        for (UserInRoom userInRoom : joinedRooms) {
+            GroupRoutineList group = userInRoom.getGroupRoutineList();
+            groupRoutineListDoneCheckRepository.deleteByGroupRoutineListAndUser(group, user);
+            userInRoomRepository.delete(userInRoom);
+            group.decreaseUserCnt();
+        }
+        userInRoomRepository.deleteAllByUser(user);
+
+        // 사용자가 작성한 기타 데이터 정리
+        guestbookRepository.deleteAllByUser(user);
+        groupRoutineListDoneCheckRepository.deleteAllByUser(user);
+        routineRecordRepository.deleteAllByUser(user);
+
+        // 최종적으로 사용자 삭제
+        userRepository.delete(user);
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #81 

## 💬 리뷰 포인트
> 여러 버그 및 못했던 기능 개발 진행

## 🚀 상세 설명
- 개인/단체루틴 "전체"조회 시 완료 요일 표시 추가
- 마케팅 수신동의 → false로 안바뀌는 문제 해결
- 단체루틴 상세조회 → 단체 루틴 상세에서 이모지 url로 변경
- 회원탈퇴 API 구현

## 📸 스크린샷

## 📢 노트